### PR TITLE
fix missing first build initial value

### DIFF
--- a/lib/pin_input_text_field.dart
+++ b/lib/pin_input_text_field.dart
@@ -319,18 +319,21 @@ class _PinInputTextFieldState extends State<PinInputTextField> {
 
   void _pinChanged() {
     setState(() {
-      if (_effectiveController.text.runes.length > widget.pinLength) {
-        _text = String.fromCharCodes(
-            _effectiveController.text.runes.take(widget.pinLength));
-      } else {
-        _text = _effectiveController.text;
-      }
-
+      _updateText();
       /// This below code will cause dead loop in iOS,
       /// you should assign selection when you set text.
 //      _effectiveController.selection = TextSelection.collapsed(
 //          offset: _effectiveController.text.runes.length);
     });
+  }
+
+  void _updateText() {
+    if (_effectiveController.text.runes.length > widget.pinLength) {
+      _text = String.fromCharCodes(
+          _effectiveController.text.runes.take(widget.pinLength));
+    } else {
+      _text = _effectiveController.text;
+    }
   }
 
   @override
@@ -340,7 +343,7 @@ class _PinInputTextFieldState extends State<PinInputTextField> {
       _controller = TextEditingController();
     }
     _effectiveController.addListener(_pinChanged);
-    _text = _effectiveController.text;
+    _updateText();
   }
 
   @override

--- a/lib/pin_input_text_field.dart
+++ b/lib/pin_input_text_field.dart
@@ -340,6 +340,7 @@ class _PinInputTextFieldState extends State<PinInputTextField> {
       _controller = TextEditingController();
     }
     _effectiveController.addListener(_pinChanged);
+    _text = _effectiveController.text;
   }
 
   @override


### PR DESCRIPTION
This fix will make sure that the `_text` field of the state is properly set before the first build. Meaning: it will be populated with the text value of `_effectiveEditingController`.

Runes were considered when _text is set.

Should resolve #15 