### PR TITLE
fix flutter analyse

### DIFF
--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -5,6 +5,10 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:flutter_test/flutter_test.dart';
+
 void main() {
-  //TODO
+  test('example', () {
+    expect(2, 1 + 1);
+  });
 }

--- a/lib/src/widget/pin_widget.dart
+++ b/lib/src/widget/pin_widget.dart
@@ -270,11 +270,12 @@ class _PinPaint extends CustomPainter {
     this.type: PinEntryType.boxTight,
     this.themeData,
   }) : this.decoration = decoration.copyWith(
-          textStyle: decoration.textStyle ?? themeData.textTheme.headline,
+          textStyle: decoration.textStyle ?? themeData.textTheme.headline5,
           errorTextStyle: decoration.errorTextStyle ??
               themeData.textTheme.caption.copyWith(color: themeData.errorColor),
           hintTextStyle: decoration.hintTextStyle ??
-              themeData.textTheme.headline.copyWith(color: themeData.hintColor),
+              themeData.textTheme.headline5
+                  .copyWith(color: themeData.hintColor),
         );
 
   @override


### PR DESCRIPTION
'This is the term used in the 2014 version of material design. The modern term is headline5. '
      'This feature was deprecated after v1.13.8.'
Fix this lint