### PR TITLE
Disabled filled color

### DIFF
--- a/lib/src/widget/pin_widget.dart
+++ b/lib/src/widget/pin_widget.dart
@@ -317,6 +317,9 @@ class _PinInputTextFieldState extends State<PinInputTextField>
           // Disabled this as it doesn't show error or
           enabled: false,
 
+          // Disabled filled color.
+          filled: false,
+
           /// Hide the all border.
           border: InputBorder.none,
           focusedBorder: InputBorder.none,


### PR DESCRIPTION
PinInputTextField's background color will be updated via Theme color of `inputDecorationTheme`, So I disabled `filled` option.