### PR TITLE
Correctly remove&add FocusNode listener

### DIFF
--- a/lib/src/widget/pin_widget.dart
+++ b/lib/src/widget/pin_widget.dart
@@ -204,9 +204,9 @@ class _PinInputTextFieldState extends State<PinInputTextField>
       widget.controller!.addListener(_pinChanged);
     }
 
-    if (_effectiveFocusNode != oldWidget.focusNode) {
-      oldWidget.focusNode?.removeListener(_handleFocusChanged);
-      _effectiveFocusNode.addListener(_handleFocusChanged);
+    if (widget.focusNode != oldWidget.focusNode) {
+      (oldWidget.focusNode ?? _focusNode)?.removeListener(_handleFocusChanged);
+      (widget.focusNode ?? _focusNode)?.addListener(_handleFocusChanged);
     }
 
     /// If the newLength is shorter than now and the current text length longer


### PR DESCRIPTION
The current implementation adds the same listener on each update to the widget _when `focusNode` is null_. This change fixes it.

This is exactly what Flutter does in the framework in many places:

https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/text_field.dart#L959-L962