### PR TITLE
Fixed `Cursor` overriding `HintText`

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -498,6 +498,7 @@ class ExampleDecoration extends PinDecoration {
     String text,
     int pinLength,
     Cursor cursor,
+    TextDirection textDirection,
   ) {
     /// You can draw anything you want here.
     canvas.drawLine(

--- a/lib/src/cursor/cursor_painter.dart
+++ b/lib/src/cursor/cursor_painter.dart
@@ -7,6 +7,33 @@ abstract class ICursorPaint {
 }
 
 mixin CursorPaint implements ICursorPaint {
+  /* Try and fix [Cursor] overriding [HintText] due to them being
+   * displayed in the same location on screen (both entered in the box).
+   * Idea:
+   *   - [Cursor] and [HintText] should coexist and be displayed at the
+   *     same time
+   *   - for visual integrity, entering a character and changing visual
+   *     focus to the next pin field should lead to only minimal changes
+   *     -> [HintText] should not have a different position with/without
+   *        [Cursor]
+   *     -> [HintText] should be displayed in the center of the box
+   *     -> [Cursor] should not be displayed in the center of the box if a
+   *        [HintText] is also present
+   *     -> [Cursor] should be displayed in front of [HintText] or behind
+   *   - [Cursor] typically is (on input fields with left-justified text) after
+   *     already typed characters
+   *   - [HintText] typically is displayed only when no characters have been
+   *     entered yet
+   *     -> [Cursor] should be displayed in front of the [HintText] at least
+   *        with TextDirection.LTR
+   *   - for minimal disruption in the existing codebase, this fix proposes to
+   *     add an optional positional or named Parameter [Offset] offset with a
+   *     default value of Offset.zero
+   *   - the offset would be added to the location given by rect prior to
+   *     drawing
+   *   - this function can then be called offsetting the [Cursor] to be drawn
+   *     to the left or right of [HintText]
+   */
   @override
   void drawCursor(Canvas canvas, Size size, Rect rect, Cursor cursor) {
     Paint paint = Paint()

--- a/lib/src/cursor/cursor_painter.dart
+++ b/lib/src/cursor/cursor_painter.dart
@@ -3,39 +3,22 @@ import 'dart:ui';
 import 'package:pin_input_text_field/src/cursor/pin_cursor.dart';
 
 abstract class ICursorPaint {
-  void drawCursor(Canvas canvas, Size size, Rect rect, Cursor cursor);
+  void drawCursor(Canvas canvas, Size size, Rect rect, Cursor cursor,
+      [Offset? offset]);
 }
 
 mixin CursorPaint implements ICursorPaint {
-  /* Try and fix [Cursor] overriding [HintText] due to them being
-   * displayed in the same location on screen (both entered in the box).
-   * Idea:
-   *   - [Cursor] and [HintText] should coexist and be displayed at the
-   *     same time
-   *   - for visual integrity, entering a character and changing visual
-   *     focus to the next pin field should lead to only minimal changes
-   *     -> [HintText] should not have a different position with/without
-   *        [Cursor]
-   *     -> [HintText] should be displayed in the center of the box
-   *     -> [Cursor] should not be displayed in the center of the box if a
-   *        [HintText] is also present
-   *     -> [Cursor] should be displayed in front of [HintText] or behind
-   *   - [Cursor] typically is (on input fields with left-justified text) after
-   *     already typed characters
-   *   - [HintText] typically is displayed only when no characters have been
-   *     entered yet
-   *     -> [Cursor] should be displayed in front of the [HintText] at least
-   *        with TextDirection.LTR
-   *   - for minimal disruption in the existing codebase, this fix proposes to
-   *     add an optional positional or named Parameter [Offset] offset with a
-   *     default value of Offset.zero
-   *   - the offset would be added to the location given by rect prior to
-   *     drawing
-   *   - this function can then be called offsetting the [Cursor] to be drawn
-   *     to the left or right of [HintText]
-   */
   @override
-  void drawCursor(Canvas canvas, Size size, Rect rect, Cursor cursor) {
+  void drawCursor(Canvas canvas, Size size, Rect rect, Cursor cursor,
+      [Offset? offset, TextDirection textDirection = TextDirection.ltr]) {
+    Offset effectiveOffset = Offset.zero;
+    if (offset != null) {
+      effectiveOffset = offset + Offset(cursor.width, 0);
+    }
+    if (textDirection == TextDirection.rtl) {
+      effectiveOffset *= -1;
+    }
+
     Paint paint = Paint()
       ..style = PaintingStyle.fill
       ..isAntiAlias = true
@@ -44,9 +27,14 @@ mixin CursorPaint implements ICursorPaint {
     double height = cursor.height ?? size.height / 3;
 
     RRect rRect = RRect.fromRectAndRadius(
-        Rect.fromLTWH(rect.center.dx - cursor.width / 2,
-            rect.center.dy - height / 2, cursor.width, height),
-        cursor.radius);
+      Rect.fromLTWH(
+        rect.center.dx - cursor.width / 2 - effectiveOffset.dx,
+        rect.center.dy - height / 2 - effectiveOffset.dy,
+        cursor.width,
+        height,
+      ),
+      cursor.radius,
+    );
     canvas.drawRRect(rRect, paint);
   }
 }

--- a/lib/src/decoration/decoration_boxloose.dart
+++ b/lib/src/decoration/decoration_boxloose.dart
@@ -87,6 +87,7 @@ class BoxLooseDecoration extends PinDecoration
     String text,
     int pinLength,
     Cursor? cursor,
+    TextDirection textDirection,
   ) {
     /// Calculate the height of paint area for drawing the pin field.
     /// it should honor the error text (if any) drawn by
@@ -183,7 +184,7 @@ class BoxLooseDecoration extends PinDecoration
           text: code,
         ),
         textAlign: TextAlign.center,
-        textDirection: TextDirection.ltr,
+        textDirection: textDirection,
       );
 
       /// Layout the text.
@@ -203,21 +204,12 @@ class BoxLooseDecoration extends PinDecoration
       index++;
     }
 
-    if (cursor != null && cursor.enabled && index < pinLength) {
-      drawCursor(
-        canvas,
-        size,
-        Rect.fromLTWH(
-          singleWidth * index +
-              actualGapSpaces.take(index).sumList() +
-              strokeWidth * (index * 2 + 1),
-          0,
-          singleWidth,
-          size.height,
-        ),
-        cursor,
-      );
-    } else if (hintText != null) {
+    /// Setup the cursor.
+    final int cursorIndex = index;
+    Offset? cursorOffset;
+
+    /// Fill the remaining space with hint text.
+    if (hintText != null) {
       hintText!.substring(index).runes.forEach((rune) {
         String code = String.fromCharCode(rune);
         textPainter = TextPainter(
@@ -226,11 +218,16 @@ class BoxLooseDecoration extends PinDecoration
             text: code,
           ),
           textAlign: TextAlign.center,
-          textDirection: TextDirection.ltr,
+          textDirection: textDirection,
         );
 
         /// Layout the text.
         textPainter.layout();
+
+        /// Save the size of the first hint text to offset the cursor.
+        if (index == cursorIndex) {
+          cursorOffset = Offset(textPainter.size.width / 2, 0);
+        }
 
         startY = mainHeight / 2 - textPainter.height / 2;
         startX = singleWidth * index +
@@ -242,6 +239,25 @@ class BoxLooseDecoration extends PinDecoration
         textPainter.paint(canvas, Offset(startX, startY));
         index++;
       });
+    }
+
+    /// Draw the cursor if provided.
+    if (cursor != null && cursor.enabled && cursorIndex < pinLength) {
+      drawCursor(
+        canvas,
+        size,
+        Rect.fromLTWH(
+          singleWidth * cursorIndex +
+              actualGapSpaces.take(cursorIndex).sumList() +
+              strokeWidth * (cursorIndex * 2 + 1),
+          0,
+          singleWidth,
+          size.height,
+        ),
+        cursor,
+        cursorOffset,
+        textDirection,
+      );
     }
   }
 

--- a/lib/src/decoration/decoration_boxtight.dart
+++ b/lib/src/decoration/decoration_boxtight.dart
@@ -74,6 +74,7 @@ class BoxTightDecoration extends PinDecoration with CursorPaint {
     String text,
     int pinLength,
     Cursor? cursor,
+    TextDirection textDirection,
   ) {
     /// Calculate the height of paint area for drawing the pin field.
     /// it should honor the error text (if any) drawn by
@@ -166,7 +167,7 @@ class BoxTightDecoration extends PinDecoration with CursorPaint {
           text: code,
         ),
         textAlign: TextAlign.center,
-        textDirection: TextDirection.ltr,
+        textDirection: textDirection,
       );
 
       /// Layout the text.
@@ -184,19 +185,12 @@ class BoxTightDecoration extends PinDecoration with CursorPaint {
       index++;
     }
 
-    if (cursor != null && cursor.enabled && index < pinLength) {
-      drawCursor(
-        canvas,
-        size,
-        Rect.fromLTWH(
-          singleWidth * index + strokeWidth * index,
-          0,
-          singleWidth,
-          size.height,
-        ),
-        cursor,
-      );
-    } else if (hintText != null) {
+    /// Setup the cursor.
+    final int cursorIndex = index;
+    Offset? cursorOffset;
+
+    /// Fill the remaining space with hint text.
+    if (hintText != null) {
       hintText!.substring(index).runes.forEach((rune) {
         String code = String.fromCharCode(rune);
         textPainter = TextPainter(
@@ -205,11 +199,16 @@ class BoxTightDecoration extends PinDecoration with CursorPaint {
             text: code,
           ),
           textAlign: TextAlign.center,
-          textDirection: TextDirection.ltr,
+          textDirection: textDirection,
         );
 
         /// Layout the text.
         textPainter.layout();
+
+        /// Save the size of the first hint text to offset the cursor.
+        if (index == cursorIndex) {
+          cursorOffset = Offset(textPainter.size.width / 2, 0);
+        }
 
         startY = mainHeight / 2 - textPainter.height / 2;
         startX = strokeWidth * (index + 1) +
@@ -219,6 +218,23 @@ class BoxTightDecoration extends PinDecoration with CursorPaint {
         textPainter.paint(canvas, Offset(startX, startY));
         index++;
       });
+    }
+
+    /// Draw the cursor if provided.
+    if (cursor != null && cursor.enabled && cursorIndex < pinLength) {
+      drawCursor(
+        canvas,
+        size,
+        Rect.fromLTWH(
+          singleWidth * cursorIndex + strokeWidth * cursorIndex,
+          0,
+          singleWidth,
+          size.height,
+        ),
+        cursor,
+        cursorOffset,
+        textDirection,
+      );
     }
   }
 

--- a/lib/src/decoration/decoration_circle.dart
+++ b/lib/src/decoration/decoration_circle.dart
@@ -81,6 +81,7 @@ class CirclePinDecoration extends PinDecoration
     String text,
     int pinLength,
     Cursor? cursor,
+    TextDirection textDirection,
   ) {
     /// Calculate the height of paint area for drawing the pin field.
     /// it should honor the error text (if any) drawn by
@@ -179,7 +180,7 @@ class CirclePinDecoration extends PinDecoration
           text: code,
         ),
         textAlign: TextAlign.center,
-        textDirection: TextDirection.ltr,
+        textDirection: textDirection,
       );
 
       /// Layout the text.
@@ -198,19 +199,12 @@ class CirclePinDecoration extends PinDecoration
       index++;
     }
 
-    if (cursor != null && cursor.enabled && index < pinLength) {
-      drawCursor(
-        canvas,
-        size,
-        Rect.fromLTWH(
-          radius * index * 2 + actualGapSpaces.take(index).sumList(),
-          0,
-          radius * 2,
-          size.height,
-        ),
-        cursor,
-      );
-    } else if (hintText != null) {
+    /// Setup the cursor.
+    final int cursorIndex = index;
+    Offset? cursorOffset;
+
+    /// Fill the remaining space with hint text.
+    if (hintText != null) {
       hintText!.substring(index).runes.forEach((rune) {
         String code = String.fromCharCode(rune);
         textPainter = TextPainter(
@@ -219,17 +213,40 @@ class CirclePinDecoration extends PinDecoration
             text: code,
           ),
           textAlign: TextAlign.center,
-          textDirection: TextDirection.ltr,
+          textDirection: textDirection,
         );
 
         /// Layout the text.
         textPainter.layout();
+
+        /// Save the size of the first hint text to offset the cursor.
+        if (index == cursorIndex) {
+          cursorOffset = Offset(textPainter.size.width / 2, 0);
+        }
 
         startY = mainHeight / 2 - textPainter.height / 2;
         textPainter.paint(canvas,
             Offset(centerPoints[index] - textPainter.width / 2, startY));
         index++;
       });
+    }
+
+    /// Draw the cursor if provided.
+    if (cursor != null && cursor.enabled && cursorIndex < pinLength) {
+      drawCursor(
+        canvas,
+        size,
+        Rect.fromLTWH(
+          radius * cursorIndex * 2 +
+              actualGapSpaces.take(cursorIndex).sumList(),
+          0,
+          radius * 2,
+          size.height,
+        ),
+        cursor,
+        cursorOffset,
+        textDirection,
+      );
     }
   }
 

--- a/lib/src/decoration/decoration_underline.dart
+++ b/lib/src/decoration/decoration_underline.dart
@@ -87,6 +87,7 @@ class UnderlineDecoration extends PinDecoration
     String text,
     int pinLength,
     Cursor? cursor,
+    TextDirection textDirection,
   ) {
     /// Calculate the height of paint area for drawing the pin field.
     /// it should honor the error text (if any) drawn by
@@ -169,7 +170,7 @@ class UnderlineDecoration extends PinDecoration
           text: code,
         ),
         textAlign: TextAlign.center,
-        textDirection: TextDirection.ltr,
+        textDirection: textDirection,
       );
 
       /// Layout the text.
@@ -187,19 +188,12 @@ class UnderlineDecoration extends PinDecoration
       index++;
     }
 
-    if (cursor != null && cursor.enabled && index < pinLength) {
-      drawCursor(
-        canvas,
-        size,
-        Rect.fromLTWH(
-          singleWidth * index + actualGapSpaces.take(index).sumList(),
-          0,
-          singleWidth,
-          size.height,
-        ),
-        cursor,
-      );
-    } else if (hintText != null) {
+    /// Setup the cursor.
+    final int cursorIndex = index;
+    Offset? cursorOffset;
+
+    /// Fill the remaining space with hint text.
+    if (hintText != null) {
       hintText!.substring(index).runes.forEach((rune) {
         String code = String.fromCharCode(rune);
         textPainter = TextPainter(
@@ -208,11 +202,16 @@ class UnderlineDecoration extends PinDecoration
             text: code,
           ),
           textAlign: TextAlign.center,
-          textDirection: TextDirection.ltr,
+          textDirection: textDirection,
         );
 
         /// Layout the text.
         textPainter.layout();
+
+        /// Save the size of the first hint text to offset the cursor.
+        if (index == cursorIndex) {
+          cursorOffset = Offset(textPainter.size.width / 2, 0);
+        }
 
         startY = mainHeight / 2 - textPainter.height / 2;
         startX = singleWidth * index +
@@ -222,6 +221,24 @@ class UnderlineDecoration extends PinDecoration
         textPainter.paint(canvas, Offset(startX, startY));
         index++;
       });
+    }
+
+    /// Draw the cursor if provided.
+    if (cursor != null && cursor.enabled && cursorIndex < pinLength) {
+      drawCursor(
+        canvas,
+        size,
+        Rect.fromLTWH(
+          singleWidth * cursorIndex +
+              actualGapSpaces.take(cursorIndex).sumList(),
+          0,
+          singleWidth,
+          size.height,
+        ),
+        cursor,
+        cursorOffset,
+        textDirection,
+      );
     }
   }
 

--- a/lib/src/decoration/pin_decoration.dart
+++ b/lib/src/decoration/pin_decoration.dart
@@ -64,6 +64,7 @@ abstract class PinDecoration {
     String text,
     int pinLength,
     Cursor? cursor,
+    TextDirection textDirection,
   );
 
   void notifyChange(String pin);

--- a/lib/src/widget/pin_widget.dart
+++ b/lib/src/widget/pin_widget.dart
@@ -234,6 +234,7 @@ class _PinInputTextFieldState extends State<PinInputTextField>
       decoration: widget.decoration,
       themeData: Theme.of(context),
       cursor: widget.cursor.copyWith(color: _cursorColor),
+      textDirection: Directionality.of(context),
     );
     return CustomPaint(
       /// The foreground paint to display pin.
@@ -540,6 +541,7 @@ class _PinPaint extends CustomPainter {
   final PinDecoration decoration;
   final ThemeData themeData;
   Cursor? cursor;
+  TextDirection textDirection;
 
   _PinPaint({
     required this.text,
@@ -548,6 +550,7 @@ class _PinPaint extends CustomPainter {
     this.type = PinEntryType.boxTight,
     required this.themeData,
     this.cursor,
+    this.textDirection = TextDirection.ltr,
   }) : decoration = decoration.copyWith(
           textStyle: decoration.textStyle ?? themeData.textTheme.headline5,
           errorTextStyle: decoration.errorTextStyle ??
@@ -564,7 +567,7 @@ class _PinPaint extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     // print('color: ${cursor.color} ${this.cursor.color}');
-    decoration.drawPin(canvas, size, text, pinLength, cursor);
+    decoration.drawPin(canvas, size, text, pinLength, cursor, textDirection);
   }
 
   _PinPaint copyWith({


### PR DESCRIPTION
Since the introduction of a `Cursor` in version 3.2.0, if enabled said `Cursor` would override any `HintText` due to them being displayed in the same location on screen (both centered in the box).
This PR addresses that issue and proposes a solution that can display both a `Cursor` and `HintText` at the same time.

### premises
- `Cursor` and `HintText` should coexist and be displayed at the same time
- for visual integrity, entering a character and changing visual focus to the next pin field should lead to only minimal changes
- `HintText` should not have a different position with/without `Cursor`
- `HintText` should be displayed in the center of the box
- `Cursor` should not be displayed in the center of the box if a `HintText` is also present
- `Cursor` should be displayed in front of `HintText` or behind
- `Cursor` typically is (on input fields with left-justified text) after already typed characters
- `HintText` typically is displayed only when no characters have been entered yet
- `Cursor` should be displayed in front of the `HintText` at least with `TextDirection.ltr`

### proposed fix
- for minimal disruption in the existing codebase, this fix proposes to add an optional positional parameter `Offset offset` with a default value of `Offset.zero`
- the offset would be added to the location given by rect prior to drawing
- on `TextDirection.ltr` the `Cursor` is drawn to the left of `HintText`, on `TextDirection.rtl` it is drawn to the right

### side effects
- a `TextDirection` parameter was added